### PR TITLE
adds bundle-collapser to build process

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,9 +19,10 @@ var isProd = false;
 var gulp = require('gulp'),
     fs = require('fs'),
     del = require('del'),
-    watch = require('gulp-watch')
+    watch = require('gulp-watch'),
     watchify = require('watchify'),
     browserify = require('browserify'),
+    collapser = require( 'bundle-collapser/plugin' ),
     source = require('vinyl-source-stream'),
     gutil = require('gulp-util'),
     babelify = require('babelify'),
@@ -34,6 +35,8 @@ var gulp = require('gulp'),
     replace = require('gulp-replace'),
     bump = require('gulp-bump');
 var version = null;
+
+
 
 function createBundle(url) {
   return browserify({
@@ -71,7 +74,7 @@ function buildBundle(bundleName) {
   return b.pipe(license('Apache', {
       organization: 'Google Inc. All rights reserved.'
     }))
-    .pipe(gulp.dest('./dist/scripts'))
+    .pipe(gulp.dest('./dist/scripts'));
 }
 
 var bundles = {
@@ -110,7 +113,7 @@ gulp.task('styles', function() {
       .pipe(license('Apache', {
         organization: 'Google Inc. All rights reserved.'
       }))
-      .pipe(gulp.dest('./dist/styles'))
+      .pipe(gulp.dest('./dist/styles'));
 });
 
 /** Scripts */
@@ -119,16 +122,16 @@ gulp.task('scripts', function() {
   for (var b = 0; b < bundleKeys.length; b++) {
     buildBundle(bundleKeys[b]);
   }
-})
+});
 
 /** Root */
 gulp.task('root', function() {
   gulp.src('./src/*.*')
     .pipe(replace(/@VERSION@/g, version))
-    .pipe(gulp.dest('./dist/'))
+    .pipe(gulp.dest('./dist/'));
 
   gulp.src('./src/favicon.ico')
-    .pipe(gulp.dest('./dist/'))
+    .pipe(gulp.dest('./dist/'));
 });
 
 /** HTML */
@@ -136,26 +139,26 @@ gulp.task('html', function() {
 
   gulp.src('./src/**/*.html')
     .pipe(replace(/@VERSION@/g, version))
-    .pipe(gulp.dest('./dist/'))
+    .pipe(gulp.dest('./dist/'));
 });
 
 /** Images */
 gulp.task('images', function() {
   gulp.src('./src/images/**/*.*')
-    .pipe(gulp.dest('./dist/images'))
+    .pipe(gulp.dest('./dist/images'));
 });
 
 /** Third Party */
 gulp.task('third_party', function() {
   gulp.src('./src/third_party/**/*.*')
-    .pipe(gulp.dest('./dist/third_party'))
+    .pipe(gulp.dest('./dist/third_party'));
 });
 
 /** Service Worker */
 gulp.task('serviceworker', function() {
   gulp.src('./src/scripts/sw.js')
     .pipe(replace(/@VERSION@/g, version))
-    .pipe(gulp.dest('./dist/scripts'))
+    .pipe(gulp.dest('./dist/scripts'));
 });
 
 /** Watches */
@@ -196,8 +199,15 @@ gulp.task('bump', function() {
 
 gulp.task('default', function() {
   isProd = true;
+
+  // add collapser to minify the output
+  Object.keys(bundles)
+    .forEach(function (key) {
+      bundles[key].bundle = bundles[key].bundle.plugin(collapser);
+    });
+
   return runSequence('clean', 'bump', 'getversion', allTasks);
-})
+});
 
 gulp.task('dev', function() {
   return runSequence('clean', 'getversion', allTasks, 'watch');

--- a/package.json
+++ b/package.json
@@ -1,31 +1,35 @@
 {
-  "name": "Voice Memos",
+  "name": "Voice_Memos",
   "version": "0.1.26",
   "private": true,
   "engines": {
     "node": ">=0.10.0"
   },
+  "scripts": {
+    "gulp": "gulp"
+  },
   "devDependencies": {
-    "gulp-qunit": "^1.2.1",
-    "gulp": "^3.8.11",
-    "watchify": "^3.1.1",
-    "browserify": "^9.0.8",
-    "gulp-watchify": "^0.5.0",
-    "vinyl-source-stream": "^1.1.0",
-    "vinyl-buffer": "^1.0.0",
-    "gulp-util": "^3.0.4",
-    "lodash.assign": "^3.1.0",
     "babelify": "^6.0.2",
-    "gulp-watch": "^4.2.4",
+    "browserify": "^9.0.8",
+    "bundle-collapser": "^1.2.0",
+    "del": "^1.1.1",
+    "gulp": "^3.8.11",
+    "gulp-bump": "^0.3.0",
+    "gulp-license": "^1.0.0",
     "gulp-minify-css": "^1.1.0",
-    "gulp-uglify": "^1.2.0",
+    "gulp-qunit": "^1.2.1",
     "gulp-rename": "^1.2.2",
+    "gulp-replace": "^0.5.3",
     "gulp-sass": "^1.3.3",
     "gulp-streamify": "0.0.5",
-    "del": "^1.1.1",
+    "gulp-uglify": "^1.2.0",
+    "gulp-util": "^3.0.4",
+    "gulp-watch": "^4.2.4",
+    "gulp-watchify": "^0.5.0",
+    "lodash.assign": "^3.1.0",
     "run-sequence": "^1.1.0",
-    "gulp-license": "^1.0.0",
-    "gulp-bump": "^0.3.0",
-    "gulp-replace": "^0.5.3"
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0",
+    "watchify": "^3.1.1"
   }
 }


### PR DESCRIPTION
- adds [`bundle-collapser`](https://github.com/substack/bundle-collapser) to the build process (this will reduce the JS the output a bit)
- changes project name in `package.json` in order to make `npm work` (install, etc), as project name cannot contain white-space
- adds `script` property in `package.json` in order not to force `gulp` being installed globally (now you can go `npm run gulp -- [gulp task or sth]`, see https://docs.npmjs.com/cli/run-script)
