### PR TITLE
Remove obsolete Chrome Frame opt-in

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,7 @@ limitations under the License.
 
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="author" content="Paul Lewis" />
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
     <meta id="theme-color" name="theme-color" content="#4527A0">


### PR DESCRIPTION
Google Chrome Frame has been retired in Feb 2014. The sole purpose of the `chrome=1` value on the `X-UA-Compatible` meta tag was to opt into Chrome Frame. Because setting `chrome=1` has no effect at all, and as Google recommended 2 years ago, one "can remove these opt-in headers and metadata now, and slim down the bytes sent to users" [1](https://archive.is/SjDdt).
