### PR TITLE
Tidy up main role

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -46,7 +46,7 @@ limitations under the License.
         <h1 class="header__title">Voice Memos</h1>
     </header>
 
-    <main class="main js-main" aria-role="main">
+    <main class="main js-main">
       <div class="main__inner">
         <section class="list-view js-list-view">
 


### PR DESCRIPTION
Was just playing around with Lighthouse and noticed this issue.

`aria-role=""` should be `role=""`. But you don't actually need a role on main because it already has an implicit role (of main) :D